### PR TITLE
fix: Resolve Tailwind CSS and PostCSS configuration conflict

### DIFF
--- a/ViralStock/frontend/package-lock.json
+++ b/ViralStock/frontend/package-lock.json
@@ -11,7 +11,6 @@
 				"@sveltejs/adapter-auto": "^6.0.0",
 				"@sveltejs/kit": "^2.22.0",
 				"@sveltejs/vite-plugin-svelte": "^6.0.0",
-				"@tailwindcss/postcss": "^4.1.13",
 				"@tailwindcss/vite": "^4.1.13",
 				"autoprefixer": "^10.4.21",
 				"postcss": "^8.5.6",
@@ -20,19 +19,6 @@
 				"tailwindcss": "^4.1.13",
 				"typescript": "^5.0.0",
 				"vite": "^7.0.4"
-			}
-		},
-		"node_modules/@alloc/quick-lru": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1206,20 +1192,6 @@
 			],
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/@tailwindcss/postcss": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.13.tgz",
-			"integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@alloc/quick-lru": "^5.2.0",
-				"@tailwindcss/node": "4.1.13",
-				"@tailwindcss/oxide": "4.1.13",
-				"postcss": "^8.4.41",
-				"tailwindcss": "4.1.13"
 			}
 		},
 		"node_modules/@tailwindcss/vite": {

--- a/ViralStock/frontend/package.json
+++ b/ViralStock/frontend/package.json
@@ -15,7 +15,6 @@
 		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
-		"@tailwindcss/postcss": "^4.1.13",
 		"@tailwindcss/vite": "^4.1.13",
 		"autoprefixer": "^10.4.21",
 		"postcss": "^8.5.6",

--- a/ViralStock/frontend/postcss.config.js
+++ b/ViralStock/frontend/postcss.config.js
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}


### PR DESCRIPTION
This commit fixes a PostCSS error that occurred when running the dev server. The error was caused by a conflict between the `@tailwindcss/vite` plugin and a manual `postcss.config.js` file.

The fix involves:
- Uninstalling the redundant `@tailwindcss/postcss` package.
- Removing the `postcss.config.js` file to rely solely on the `@tailwindcss/vite` plugin for PostCSS configuration.